### PR TITLE
Use relative path to esptool.py, closes #1

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -168,7 +168,7 @@ void MainWindow::firmwareInfo() {
     arguments << "image_info" << firmwarePath;
 
     // Call esptool
-    QString program = "/usr/bin/esptool.py";
+    QString program = QCoreApplication::applicationDirPath() + QString("/esptool.py");
     esptool = new QProcess(this);
     esptool->start(program, arguments);
 
@@ -234,7 +234,7 @@ void MainWindow::flashFirmware() {
     }
 
     // Create process and connect signals
-    QString program = "/usr/bin/esptool.py";
+    QString program = QCoreApplication::applicationDirPath() + QString("/esptool.py");
     esptool = new QProcess(this);
     esptool->setProcessChannelMode(QProcess::MergedChannels);
 


### PR DESCRIPTION
This makes it work when `esptool.py` is privately bundled with CuteESP in a location other than `/usr/bin`.